### PR TITLE
Update music pages with platform links and improve styling

### DIFF
--- a/live-at-the-windmill.html
+++ b/live-at-the-windmill.html
@@ -28,16 +28,19 @@
   </nav>
 
   <h1 class="neon">LIVE AT THE WINDMILL</h1>
-  <p class="tag">release page — add your platform links below</p>
 
   <hr class="kitt">
 
-  <img src="https://via.placeholder.com/400.png?text=Cover+Art+Placeholder" alt="cover" class="release-cover">
-  <p>Use this page to add links for Spotify, Bandcamp, Apple Music, etc.</p>
+  <img src="assets/live at windmill cover art.png" alt="cover" class="release-cover">
 
-  <div style="max-width:700px;text-align:left;margin:0 auto;padding:8px;background:var(--panel);border:1px solid var(--mint);">
+  <div style="max-width:700px;margin:0 auto;padding:8px;background:var(--panel);border:1px solid var(--mint);">
     <!-- Add platform links here -->
-    <p><a class="retro-btn" href="#">Spotify</a> <a class="retro-btn" href="#">Bandcamp</a> <a class="retro-btn" href="#">Apple Music</a></p>
+    <div class="platform-links">
+      <a class="retro-btn" target="_blank" href="https://open.spotify.com/album/0V5DeEQfHVf7pRJu1qoAhO?si=BvMFoY5IR--YXRcR8LtTKg">Spotify</a>
+      <a class="retro-btn" target="_blank" href="https://showza.bandcamp.com/album/live-at-the-windmill">Bandcamp</a>
+      <a class="retro-btn" target="_blank" href="https://music.apple.com/us/album/live-at-the-windmill-live-at-the-windmill/1839972170">Apple Music</a>
+      <a class="retro-btn" target="_blank" href="https://www.youtube.com/watch?v=ZfR2YrvDfEA&list=OLAK5uy_nqecEl976Y8hRfoGwdA0QV74IIbKfRurM">YouTube</a>
+    </div>
   </div>
 
   <hr class="kitt">

--- a/north-camp.html
+++ b/north-camp.html
@@ -28,16 +28,19 @@
   </nav>
 
   <h1 class="neon">NORTH CAMP</h1>
-  <p class="tag">single — add your platform links below</p>
 
   <hr class="kitt">
 
-  <img src="https://via.placeholder.com/400.png?text=Cover+Art+Placeholder" alt="cover" class="release-cover">
-  <p>Use this page to add platform links for the single.</p>
+  <img src="assets/North Camp Cover Art.png" alt="image of beans" class="release-cover">
 
-  <div style="max-width:700px;text-align:left;margin:0 auto;padding:8px;background:var(--panel);border:1px solid var(--mint);">
+  <div style="max-width:700px;margin:0 auto;padding:8px;background:var(--panel);border:1px solid var(--mint);">
     <!-- Add platform links here -->
-    <p><a class="retro-btn" href="#">Spotify</a> <a class="retro-btn" href="#">Bandcamp</a> <a class="retro-btn" href="#">Apple Music</a></p>
+    <div class="platform-links">
+      <a class="retro-btn" target="_blank" href="https://open.spotify.com/track/5Zo71MLWTfAnRWUA3J6ty5?si=a79eb44f200848dd">Spotify</a>
+      <a class="retro-btn" target="_blank" href="https://showza.bandcamp.com/track/north-camp">Bandcamp</a>
+      <a class="retro-btn" target="_blank" href="https://music.apple.com/us/album/north-camp-single/1817922519">Apple Music</a>
+      <a class="retro-btn" target="_blank" href="https://youtu.be/b9qjftQYYyM?si=PaoAISE1iIp3dqze">YouTube</a>
+    </div>
   </div>
 
   <hr class="kitt">

--- a/stick-swords.html
+++ b/stick-swords.html
@@ -28,16 +28,19 @@
   </nav>
 
   <h1 class="neon">STICK SWORDS</h1>
-  <p class="tag">album — add your platform links below</p>
-
+  
   <hr class="kitt">
 
-  <img src="https://via.placeholder.com/400.png?text=Cover+Art+Placeholder" alt="cover" class="release-cover">
-  <p>Use this page to add links for Bandcamp, Spotify and other platforms.</p>
+  <img src="assets/stick swords cover art.png" alt="cover" class="release-cover">
 
-  <div style="max-width:700px;text-align:left;margin:0 auto;padding:8px;background:var(--panel);border:1px solid var(--mint);">
+  <div style="max-width:700px;margin:0 auto;padding:8px;background:var(--panel);border:1px solid var(--mint);">
     <!-- Add platform links here -->
-    <p><a class="retro-btn" href="#">Bandcamp</a> <a class="retro-btn" href="#">Spotify</a> <a class="retro-btn" href="#">Apple Music</a></p>
+    <div class="platform-links">
+      <a class="retro-btn" target="_blank" href="https://open.spotify.com/album/76WcNUKg6usivB3pxThYi2?si=D-94iZs-TFGukYdDIWNDGg">Spotify</a>
+      <a class="retro-btn" target="_blank" href="https://showza.bandcamp.com/album/stick-swords">Bandcamp</a>
+      <a class="retro-btn" target="_blank" href="https://music.apple.com/us/album/stick-swords/1816701125">Apple Music</a>
+      <a class="retro-btn" target="_blank" href="https://www.youtube.com/watch?v=i63mVfUL7M8&list=OLAK5uy_m4RJfAWzjtkt4XLw7NG6zAFyqZujILMsA">YouTube</a>
+    </div>
   </div>
 
   <hr class="kitt">

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,10 @@ center{position:relative; z-index:1}
 .links a{color:var(--mint)}
 .legal{font-size:12px;color:orange}
 
+/* Platform links row on release pages */
+.platform-links{display:flex;flex-wrap:wrap;justify-content:space-between;gap:8px;}
+.platform-links .retro-btn{flex:1;text-align:center;margin-right:0;}
+
 /* Releases grid */
 .releases{display:flex;flex-wrap:wrap;gap:18px;justify-content:center;margin-top:8px}
 .release{width:300px;text-align:center}
@@ -93,11 +97,13 @@ img, .CENy8b { max-width:100%; height:auto; display:block; }
 @media (max-width:640px){
 	/* Avoid hiding all tables — target only layout tables if needed via `.hide-on-mobile` */
 	table.hide-on-mobile { display:none; }
+	.platform-links{flex-direction:column;align-items:center;}
+	.platform-links .retro-btn{width:90%;flex:unset;}
 	.hamburger{display:block}
 	.nav-links{display:none;flex-direction:column;width:100%;align-items:center}
 	.nav-links.open{display:flex}
 	.nav{ display:block; width:90%; margin:8px auto; font-size:18px; padding:12px 10px; box-sizing:border-box; text-align:center}
-	.retro-btn{ display:block; width:90%; margin:8px auto; padding:12px; font-size:16px; }
+	.retro-btn{ display:block; width:90%; margin:8px auto; padding:12px; font-size:21px; }
 	.neon{font-size:40px}
 	.tag{font-size:16px}
 	.list{padding-left:12px}


### PR DESCRIPTION
Basically just added links and made the styling a bit better.
Here is the formal version.

This pull request updates the release pages for "LIVE AT THE WINDMILL," "NORTH CAMP," and "STICK SWORDS" to include real cover art and working platform links. Additionally, it introduces a new `platform-links` layout for these links and improves their styling and mobile responsiveness in `styles.css`.

**Release page content updates:**

* Replaced placeholder cover images with actual cover art and removed instructional text on `live-at-the-windmill.html`, `north-camp.html`, and `stick-swords.html`. [[1]](diffhunk://#diff-ce047d3468c982a0b798e7fd54d1445de4f272dfbc0160cd2267cc85f780c4e7L31-R43) [[2]](diffhunk://#diff-382e32cecd800fb7efa3c26b14534a98777794c503e8771a3144ba7aabc00dfbL31-R43) [[3]](diffhunk://#diff-b6b35083b870821b559d7dadfca74663a3f6d6d8d8d76bcfe9004081845709b9L31-R43)
* Added real, platform-specific links (Spotify, Bandcamp, Apple Music, YouTube) for each release, using a new `.platform-links` container for improved layout. [[1]](diffhunk://#diff-ce047d3468c982a0b798e7fd54d1445de4f272dfbc0160cd2267cc85f780c4e7L31-R43) [[2]](diffhunk://#diff-382e32cecd800fb7efa3c26b14534a98777794c503e8771a3144ba7aabc00dfbL31-R43) [[3]](diffhunk://#diff-b6b35083b870821b559d7dadfca74663a3f6d6d8d8d76bcfe9004081845709b9L31-R43)

**Styling and layout improvements:**

* Introduced the `.platform-links` CSS class to arrange platform buttons in a flexible row layout on desktop, and as a centered column on mobile. [[1]](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1R69-R72) [[2]](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1R100-R106)
* Increased the font size of `.retro-btn` buttons on mobile for better accessibility and visual consistency.